### PR TITLE
Prouser123/PyOS#17 updater: Using distutils LooseVersion

### DIFF
--- a/internal/update/runscript.py
+++ b/internal/update/runscript.py
@@ -4,6 +4,7 @@
 
 # See ghstatscustom.py for more infomation.
 
+from distutils.version import LooseVersion
 # Import custom file
 import internal.update.ghstatscustom as ghstatscustom
 # PyOS Scripts
@@ -27,7 +28,7 @@ def app():
 	print("Installed Version: " + internal.extra.colors.WARNING + internal.extra.notes.ver + internal.extra.colors.ENDC)
 	print("Newest Version: " + internal.extra.colors.WARNING + ver + internal.extra.colors.ENDC)
 	try:
-		if (float(internal.extra.notes.ver) >= float(ver)):
+		if LooseVersion(internal.extra.notes.ver) >= LooseVersion(ver):
 			print("You are up-to-date!")
 		else:
 			print("There is a new version available.")


### PR DESCRIPTION
The updater can't handle the M.m.b format because you can't turn it into a float.
So don't turn it into a float. One possible solution is to use LooseVersion
and saving time on reinventing the wheel.

Good luck!